### PR TITLE
Override PS1 to avoid printing terminal type

### DIFF
--- a/src/etc/post-install/99-qmk.post
+++ b/src/etc/post-install/99-qmk.post
@@ -20,3 +20,5 @@ maybe_qmk_welcome () {
 if [ "$MSYSTEM" == "MINGW64" ]; then
   maybe_qmk_welcome
 fi
+
+MSYS2_PS1='\[\e]0;\w\a\]\n\[\e[32m\][\u@\h \[\e[0m\]\w\[\e[32m\]]$\[\e[0m\] '


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Given the single shortcut the terminal is always going to be MINGW64, why bother printing it...