### PR TITLE
Default install to root of system drive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run Install
         run: |
-          Start-Process ./artifacts/QMK_MSYS.exe -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART" -wait
+          Start-Process ./artifacts/QMK_MSYS.exe -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /DIR=expand:{autopf}\QMK_MSYS" -wait
 
       - name: Run QMK cli
         env:

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -20,8 +20,9 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName={autopf}\{#MyAppDir}
+DefaultDirName={sd}\{#MyAppDir}
 DisableProgramGroupPage=yes
+UsePreviousAppDir=no
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 OutputDir=..\.build


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Reported by a user on Discord,
```console
sed: can't read C:/Program: No such file or directory
sed: can't read Files/QMK_MSYS/mingw64/bin/pip-script.py: No such file or directory
sed: can't read C:/Program: No such file or directory
sed: can't read Files/QMK_MSYS/mingw64/bin/pip3-script.py: No such file or directory
sed: can't read C:/Program: No such file or directory
sed: can't read Files/QMK_MSYS/mingw64/bin/pip3.8-script.py: No such file or directory
error: command (/usr/bin/bash /usr/bin/bash -c . /tmp/alpm_dRUo9g/.INSTALL; post_upgrade 21.0-1 20.3.3-1 ) failed to execute correctly
(17/17) upgrading msys2-keyring                    [#####################] 100%
==> Appending keys from msys2.gpg...
==> Locally signing trusted keys in keyring...
  -> Locally signing key 123D4D51A1793859C2BE916BBBE514E53E0D0813...
  -> Locally signing key B91BCF3303284BF90CC043CA9F418C233E652008...
  -> Locally signing key 6E8FEAFF9644F54EED90EEA0790AE56A1D3CFDDC...
  -> Locally signing key 69985C5EB351011C78DF7F6D755B8182ACD22879...
  -> Locally signing key 9DD0D4217D75A33B896159E6DA7EF2ABAEEA755C...
  -> Locally signing key D55E7A6D7CE9BA1587C0ACACF40D263ECA25678A...
==> Importing owner trust values...
==> Disabling revoked keys in keyring...
  -> Disabling key B19514FB53EB3668471B296E794DCF97F93FC717...
==> Updating trust database...
gpg: next trustdb check due at 2022-01-23
```

Looks like msys currently has a few assumptions around where it is running from (and that it doesn't contain a space). While the msys packages can be fixed up, that timeframe is out of our control. For now it makes sense to copy the behaviour of others and just dump it in the root of the filesystem.