### PR TITLE
Swap from mintty to cmd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
         mkdir -p .build/msys64/dev/mqueue
         cp -rf src/* .build/msys64/
         sed -i '1i#!/usr/bin/env python3 -Xutf8\' .build/msys64/mingw64/bin/qmk-script.py
+        sed -i 's/default=True/default=False/' .build/msys64/mingw64/lib/python3.8/site-packages/milc/milc.py
         echo "VERSION_ID=$GITHUB_SHA" >> .build/msys64/etc/qmk-release
         echo "VERSION=${VERSION:-2.0.0}" >> .build/msys64/etc/qmk-release
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,8 +48,8 @@ Note that the example below assumes that you have QMK MSYS installed to the defa
     {
       "guid": "{1ca2e875-5a87-40f8-b55c-e7ec84354a92}",
       "name": "QMK MSYS2",
-      "commandline": "%PROGRAMFILES%/QMK_MSYS/msys2_shell.cmd -defterm -no-start -mingw64",
-      "icon": "%PROGRAMFILES%/QMK_MSYS/icon.ico"
+      "commandline": "%SystemDrive%/QMK_MSYS/msys2_shell.cmd -defterm -no-start -mingw64",
+      "icon": "%SystemDrive%/QMK_MSYS/icon.ico"
     }
 ```
 

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -51,5 +51,5 @@ Name:"{app}\"; Permissions:everyone-modify
 Filename: "{tmp}\qmk_driver_installer.exe"; WorkingDir: "{tmp}"; Parameters: " --all --force drivers.txt"; StatusMsg: "Installing Drivers..."; Flags: runhidden
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\usr\bin\mintty.exe"; Parameters: "-i ""{app}\icon.ico"" -T ""{#MyAppName}"" /usr/bin/bash -l -c ""MSYSTEM=MINGW64 exec -l bash"""; IconFilename: "{app}\icon.ico"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\usr\bin\mintty.exe"; Parameters: "-i ""{app}\icon.ico"" -T ""{#MyAppName}"" /usr/bin/bash -l -c ""MSYSTEM=MINGW64 exec -l bash"""; IconFilename: "{app}\icon.ico"; Tasks: desktopicon
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{cmd}"; Parameters: "/k {app}\usr\bin\bash -l -c ""MSYSTEM=MINGW64 exec -l bash"""; IconFilename: "{app}\icon.ico"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{cmd}"; Parameters: "/k {app}\usr\bin\bash -l -c ""MSYSTEM=MINGW64 exec -l bash"""; IconFilename: "{app}\icon.ico"; Tasks: desktopicon

--- a/src/etc/post-install/99-qmk.post
+++ b/src/etc/post-install/99-qmk.post
@@ -21,4 +21,5 @@ if [ "$MSYSTEM" == "MINGW64" ]; then
   maybe_qmk_welcome
 fi
 
+echo -ne "\e]0;QMK MSYS\a"
 MSYS2_PS1='\[\033[01;32m\][\u@\h\[\033[01;37m\] \W\[\033[01;32m\]]\$\[\033[00m\] '


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

The move away from mintty is for the following reasons:
1. `ctrl+c` doesnt generate keyboardinterrupt exceptions
2. cmd history doesnt work - `https://github.com/msys2/MINGW-packages/issues/7111`

Short term bodge to color to avoid qmk/qmk_cli#41
