### PR TITLE
Workaround for recent qmk_cli packaging changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman --needed --noconfirm --disable-download-timeout -S pactoys-git"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:x clang:x git: unzip: python3-pip:x python3-setuptools:x avr-binutils:x avr-gcc:x avr-libc:x arm-none-eabi-binutils:x arm-none-eabi-gcc:x arm-none-eabi-newlib:x avrdude:x bootloadhid:x dfu-programmer:x dfu-util:x mdloader:x teensy-loader-cli:x hidapi:x"
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "python3 -m pip install --src /tmp -e git+https://github.com/qmk/qmk_cli@${{ steps.dotenv.outputs.qmk_cli_ver }}#egg=qmk"
+        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "/pip_bodge.cmd install qmk==${{ steps.dotenv.outputs.qmk_cli_ver }}"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "qmk"
 
     - name: Patch Up MSYS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,13 @@ jobs:
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Syu --noconfirm || true"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Syu --noconfirm"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Su --noconfirm"
+        cp -f src/pip_bodge.cmd .build/msys64/usr/bin/
 
     - name: Install QMK cli
       run: |
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman --needed --noconfirm --disable-download-timeout -S pactoys-git"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:x clang:x git: unzip: python3-pip:x python3-setuptools:x avr-binutils:x avr-gcc:x avr-libc:x arm-none-eabi-binutils:x arm-none-eabi-gcc:x arm-none-eabi-newlib:x avrdude:x bootloadhid:x dfu-programmer:x dfu-util:x mdloader:x teensy-loader-cli:x hidapi:x"
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "src/pip_bodge.cmd install qmk==${{ steps.dotenv.outputs.qmk_cli_ver }}"
+        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pip_bodge.cmd install qmk==${{ steps.dotenv.outputs.qmk_cli_ver }}"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "qmk"
 
     - name: Patch Up MSYS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Syu --noconfirm || true"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Syu --noconfirm"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Su --noconfirm"
-        cp -f src/pip_bodge.cmd .build/msys64/usr/bin/
+        cp src/pip_bodge.cmd .build/msys64/usr/bin/
 
     - name: Install QMK cli
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman --needed --noconfirm --disable-download-timeout -S pactoys-git"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:x clang:x git: unzip: python3-pip:x python3-setuptools:x avr-binutils:x avr-gcc:x avr-libc:x arm-none-eabi-binutils:x arm-none-eabi-gcc:x arm-none-eabi-newlib:x avrdude:x bootloadhid:x dfu-programmer:x dfu-util:x mdloader:x teensy-loader-cli:x hidapi:x"
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "/pip_bodge.cmd install qmk==${{ steps.dotenv.outputs.qmk_cli_ver }}"
+        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "src/pip_bodge.cmd install qmk==${{ steps.dotenv.outputs.qmk_cli_ver }}"
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "qmk"
 
     - name: Patch Up MSYS

--- a/src/pip_bodge.cmd
+++ b/src/pip_bodge.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+python -c "from pip._internal.cli.main import main;import sys;sys.executable='python.exe';main()" %*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
Inspired by the workaround within <https://github.com/pypa/pip/issues/4616#issue-241971452>, the bodge allows a non absolute path within the pip generated exe files.