### PR TITLE
Revert "Apply suggested cygwin_exception workaround"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
     - name: Patch Up MSYS
       shell: 'bash {0}'
       run: |
-        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\editbin.exe" /stack:134217728 .build/msys64/usr/bin/make.exe
         rm -rf .build/msys64/home/*
         rm -rf .build/msys64/dev/*
         rm -rf .build/msys64/etc/mtab


### PR DESCRIPTION
Reverts qmk/qmk_distro_msys#68

No longer required since qmk/qmk_firmware#15988