### PR TITLE
Workaround for recent influx of gmake issues

### DIFF
--- a/src/etc/post-install/99-qmk.post
+++ b/src/etc/post-install/99-qmk.post
@@ -28,3 +28,6 @@ PROMPT_COMMAND="history -a; $PROMPT_COMMAND"
 
 # Force UTF8 to avoid cp1252 issues
 export PYTHONUTF8=1
+
+# Stop gmake from being picked up on the path
+export MAKE=make


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Recently there seems to be a lot of users hitting an issue where the build dies with the following output

![image](https://user-images.githubusercontent.com/16520359/169620849-1f2760ac-afba-4f53-8e65-4bce3acb2c95.png)

What seems to be consistent in all the reports so far, is that `gmake` is being picked up on the path. In the cases I have diagnosed, its been a different environment such as `strawberry perl` being on the path.

<https://github.com/qmk/qmk_firmware/blob/0103f7877a8524ab7ee8ddcfcf31aec8b117bdcf/lib/python/qmk/commands.py#L16-L24>

Annoyingly, the above logic cannot be flipped as it is currently required to work round macos make issues.