### PR TITLE
Revert "Install Visual C++ Redistributable"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,6 @@ jobs:
         curl -L --output-dir .build/drivers/ -O https://raw.githubusercontent.com/qmk/qmk_firmware/master/util/drivers.txt
         curl -L --output-dir .build/drivers/ -O https://github.com/qmk/qmk_driver_installer/releases/download/v1.01/qmk_driver_installer.exe
 
-    - name: Download Visual C++ Redistributable
-      shell: bash
-      run: |
-        mkdir .build/vcredist/
-        curl -L --output-dir .build/vcredist/ -O http://download.microsoft.com/download/c/c/2/cc2df5f8-4454-44b4-802d-5ea68d086676/vcredist_x64.exe
-
     - name: Update MSYS
       run: |
         .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Syu --noconfirm || true"

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -43,13 +43,11 @@ Name: "installdrivers"; Description: "Install drivers"; GroupDescription: "Other
 Source: ".\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\.build\msys64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\.build\drivers\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\.build\vcredist\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Dirs]
 Name:"{app}\"; Permissions:everyone-modify
 
 [Run]
-Filename: "{app}\vcredist_x64.exe"; WorkingDir: "{app}"; Parameters: " /install /quiet /norestart"; StatusMsg: "Installing Visual C++ Redistributable..."; Flags: runhidden
 Filename: "{app}\qmk_driver_installer.exe"; WorkingDir: "{app}"; Parameters: " --all --force drivers.txt"; StatusMsg: "Installing Drivers..."; Tasks: installdrivers; Flags: runhidden
 
 [Icons]


### PR DESCRIPTION
Reverts qmk/qmk_distro_msys#88

I believe this is no longer needed:
![image](https://user-images.githubusercontent.com/4781841/225814497-0041dbd4-3a6d-449b-aa7a-efd76226d7cf.png)

https://github.com/msys2/MINGW-packages/pull/11785

![image](https://user-images.githubusercontent.com/4781841/225815139-61938f2e-c111-4410-b4b9-8a219d9e35ec.png)
