### PR TITLE
Use quotes to handle install path with spaces

### DIFF
--- a/src/shell_connector.cmd
+++ b/src/shell_connector.cmd
@@ -3,4 +3,4 @@
 set MSYSTEM=MINGW64
 set MSYS2_PATH_TYPE=inherit
 
-%~dp0\usr\bin\bash.exe -l -i %*
+"%~dp0\usr\bin\bash.exe" -l -i %*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This is is just a very small change that I needed to make to get the Windows Terminal QMK profile to work.  Not sure if this file is used for anything besides Windows Terminal, but I needed to add the quotes since my install path had a folder name with a space in it.

<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
