### PR TITLE
Swap from mingw64 to ucrt64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,23 +48,23 @@ jobs:
 
     - name: Update MSYS
       run: |
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Syu --noconfirm || true"
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Syu --noconfirm"
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman -Su --noconfirm"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacman -Syu --noconfirm || true"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacman -Syu --noconfirm"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacman -Su --noconfirm"
 
     - name: Install CLI
       run: |
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacman --needed --noconfirm --disable-download-timeout -S pactoys"
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:x clang:x tree: git: jq:x ripgrep:x python-appdirs:x python-qmk:x hidapi:x"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacman --needed --noconfirm --disable-download-timeout -S pactoys"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:x clang:x tree: git: jq:x ripgrep:x python-appdirs:x python-qmk:x hidapi:x"
 
     - name: Install QMK Additional Tools
       run: |
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "mkdir -p /opt/uv/bin"
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "export UV_NO_MODIFY_PATH=1 && export UV_PYTHON_INSTALL_DIR=/opt/uv/bin && curl -fsSL https://install.qmk.fm | sh -s -- --confirm --skip-qmk-cli --skip-windows-drivers"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "mkdir -p /opt/uv/bin"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "export UV_NO_MODIFY_PATH=1 && export UV_PYTHON_INSTALL_DIR=/opt/uv/bin && curl -fsSL https://install.qmk.fm | sh -s -- --confirm --skip-qmk-cli --skip-windows-drivers"
 
     - name: Test QMK cli version
       run: |
-        .build\msys64\msys2_shell.cmd -mingw64 -defterm -no-start -c "qmk --version | grep -F ${{ steps.dotenv.outputs.qmk_cli_ver }}"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "qmk --version | grep -F ${{ steps.dotenv.outputs.qmk_cli_ver }}"
 
     - name: Patch Up MSYS
       shell: 'bash {0}'
@@ -108,7 +108,7 @@ jobs:
 
       - name: Run QMK cli
         env:
-          MSYSTEM: MINGW64
+          MSYSTEM: UCRT64
         shell: cmd
         run: |
             "%ProgramFiles%\QMK_MSYS\usr\bin\bash.exe" -l -c 'qmk -h' | findstr /c:"CLI wrapper for running QMK commands"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,12 @@ jobs:
         .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacman --needed --noconfirm --disable-download-timeout -S pactoys"
         .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:p clang:p tree: git: jq:p ripgrep:p python-appdirs:p python-qmk:p hidapi:p"
 
+    - name: Patch CLI
+      shell: 'bash {0}'
+      run: |
+        sed -i 's/MINGW64/UCRT64/g' .build/msys64/ucrt64/lib/python3.14/site-packages/qmk_cli/script_qmk.py
+        sed -i 's/mingw64/ucrt64/g' .build/msys64/ucrt64/lib/python3.14/site-packages/qmk_cli/script_qmk.py
+
     - name: Install QMK Additional Tools
       run: |
         .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "mkdir -p /opt/uv/bin"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install CLI
       run: |
         .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacman --needed --noconfirm --disable-download-timeout -S pactoys"
-        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:x clang:x tree: git: jq:x ripgrep:x python-appdirs:x python-qmk:x hidapi:x"
+        .build\msys64\msys2_shell.cmd -ucrt64 -defterm -no-start -c "pacboy sync --needed --noconfirm --disable-download-timeout base-devel: toolchain:p clang:p tree: git: jq:p ripgrep:p python-appdirs:p python-qmk:p hidapi:p"
 
     - name: Install QMK Additional Tools
       run: |

--- a/src/conemu/ConEmu.xml
+++ b/src/conemu/ConEmu.xml
@@ -392,7 +392,7 @@
 				<line data="# alias glb=git-log --branches --date-order"/>
 				<line data=" "/>
 				<line data="set CHERE_INVOKING=1"/>
-				<line data="set MSYSTEM=MINGW64"/>
+				<line data="set MSYSTEM=UCRT64"/>
 				<line data="set MSYS2_PATH_TYPE=inherit"/>
 			</value>
 			<value name="CTS.Intelligent" type="hex" data="01"/>

--- a/src/shell_connector.cmd
+++ b/src/shell_connector.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set MSYSTEM=MINGW64
+set MSYSTEM=UCRT64
 set MSYS2_PATH_TYPE=inherit
 
 %~dp0\usr\bin\bash.exe -l -i %*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
<https://www.msys2.org/news/#2026-03-15-deprecating-the-mingw64-environment>
> As support for Windows 8.1 has been dropped, there is no longer a need for non-UCRT environments such as MINGW64. Consequently, we are beginning to phase out the MINGW64 environment. To start, no new packages will be added to this environment, and existing leaf packages may be removed if issues arise. If you are currently relying on the MINGW64 environment, please consider switching to UCRT64 or CLANG64 instead.

<https://www.msys2.org/docs/environments/>
> If you are unsure, go with UCRT64.
